### PR TITLE
Replace "parts" with "effects" for mixed-models

### DIFF
--- a/R/sjPlotGLME.R
+++ b/R/sjPlotGLME.R
@@ -24,7 +24,7 @@ utils::globalVariables(c("estimate", "nQQ", "ci", "fixef", "fade", "conf.low", "
 #'            \item{\code{"fe.cor"}}{for correlation matrix of fixed effects}
 #'            \item{\code{"re.qq"}}{for a QQ-plot of random effects (random effects quantiles against standard normal quantiles)}
 #'            \item{\code{"ri.slope"}}{to plot probability or incidents curves (predicted probabilities or incidents) of random intercept variances for all fixed effects coefficients. Use \code{facet.grid} to decide whether to plot each coefficient as separate plot or as integrated faceted plot. See 'Details'.}
-#'            \item{\code{"rs.ri"}}{for fitted probability curves (predicted probabilities) indicating the random slope-intercept pairs. Use this to visualize the random parts of random slope-intercept (or repeated measure) models. When having too many groups, use \code{sample.n} argument.}
+#'            \item{\code{"rs.ri"}}{for fitted probability curves (predicted probabilities) indicating the random slope-intercept pairs. Use this to visualize the random effects of random slope-intercept (or repeated measure) models. When having too many groups, use \code{sample.n} argument.}
 #'            \item{\code{"eff"}}{to plot marginal effects of predicted probabilities or incidents for each fixed term, where remaining co-variates are set to the mean. Use \code{facet.grid} to decide whether to plot each coefficient as separate plot or as integrated faceted plot. See 'Details'.}
 #'            \item{\code{"pred"}}{to plot predicted probabilities or incidents for the response, related to specific model predictors and conditioned on random effects. See 'Details'.}
 #'            \item{\code{"pred.fe"}}{to plot predicted probabilities or incidents for the response, related to specific model predictors, only for fixed effects. See 'Details'.}
@@ -313,7 +313,7 @@ sjp.glmer <- function(fit,
 #'            set to zero, but adjusted for. This plot type differs from \code{type = "ri.slope"}
 #'            only in the adjusted y-axis-scale}
 #'            \item{\code{type = "rs.ri"}}{plots regression lines for the random
-#'            parts of the model, i.e. all random slopes for each random intercept.
+#'            effects of the model, i.e. all random slopes for each random intercept.
 #'            As the random intercepts describe the deviation from the global intercept,
 #'            the regression lines are computed as global intercept + random intercept +
 #'            random slope. In case of overplotting,
@@ -352,7 +352,7 @@ sjp.glmer <- function(fit,
 #'            \item{\code{"fe.cor"}}{for correlation matrix of fixed effects}
 #'            \item{\code{"re.qq"}}{for a QQ-plot of random effects (random effects quantiles against standard normal quantiles)}
 #'            \item{\code{"ri.slope"}}{for fixed effects slopes depending on the random intercept.}
-#'            \item{\code{"rs.ri"}}{for fitted regression lines indicating the random slope-intercept pairs. Use this to visualize the random parts of random slope-intercept (or repeated measure) models. When having too many groups, use \code{sample.n} argument.}
+#'            \item{\code{"rs.ri"}}{for fitted regression lines indicating the random slope-intercept pairs. Use this to visualize the random effects of random slope-intercept (or repeated measure) models. When having too many groups, use \code{sample.n} argument.}
 #'            \item{\code{"coef"}}{for joint (sum of) random and fixed effects coefficients for each explanatory variable for each level of each grouping factor as forest plot.}
 #'            \item{\code{"pred"}}{to plot predicted values for the response, related to specific model predictors and conditioned on random effects. See 'Details'.}
 #'            \item{\code{"pred.fe"}}{to plot predicted values for the response, related to specific model predictors and conditioned on fixed effects only. See 'Details'.}
@@ -1669,13 +1669,13 @@ sjp.lme.rsri <- function(fit,
     if (ncol(re_tmp) < 2)
       remove_ri <- c(remove_ri, h)
   }
-  # found any random parts withou slopes? if yes, remove them from index
+  # found any random effects without slopes? if yes, remove them from index
   if (!sjmisc::is_empty(remove_ri)) {
     ri.nr <- ri.nr[-remove_ri]
   }
   # nothing found?
   if (sjmisc::is_empty(ri.nr)) {
-    warning("No random parts with random-slope-intercept parameters found.", call. = F)
+    warning("No random effects with random-slope-intercept parameters found.", call. = F)
     return(NULL)
   }
   # ---------------------------------------

--- a/R/sjTabLinReg.R
+++ b/R/sjTabLinReg.R
@@ -749,7 +749,7 @@ sjt.lm <- function(...,
     group.pred.rows <- group.pred.span <- group.pred.labs <- NULL
   }
   # -------------------------------------
-  # 1. table part: "Fixed parts" - only used
+  # 1. table part: "Fixed Effects" - only used
   # for linear mixed models
   # -------------------------------------
   if (lmerob) {
@@ -1295,7 +1295,7 @@ sjt.lm <- function(...,
 #'            }
 #'            for further use.
 #'
-#' @note The variance components of the random parts (see \code{show.re.var}) are
+#' @note The variance components of the random effects (see \code{show.re.var}) are
 #'         denoted like:
 #'         \itemize{
 #'          \item within-group variance: sigma-squared

--- a/R/sjTabOdds.R
+++ b/R/sjTabOdds.R
@@ -602,7 +602,7 @@ sjt.glm <- function(...,
     page.content <- paste(page.content, "\n  </tr>\n")
   }
   # -------------------------------------
-  # 1. table part: "Fixed parts" - only used
+  # 1. table part: "Fixed Effects" - only used
   # for linear mixed models
   # -------------------------------------
   if (lmerob) {
@@ -1152,7 +1152,7 @@ sjt.glm <- function(...,
 #' @note Computation of p-values (if necessary) is based on normal-distribution
 #'         assumption, treating the t-statistics as Wald z-statistics.
 #'         \cr \cr
-#'         The variance components of the random parts (see \code{show.re.var}) are
+#'         The variance components of the random effects (see \code{show.re.var}) are
 #'         denoted like:
 #'         \itemize{
 #'          \item between-group-variance: tau-zero-zero

--- a/vignettes/sjtlmer.Rmd
+++ b/vignettes/sjtlmer.Rmd
@@ -59,8 +59,8 @@ The simplest way of producing the table output is by passing the fitted models a
 
 The resulting table is divided into three parts:
 
-1. _Fixed parts_ - the model's fixed effects coefficients, including confidence intervals and p-values.
-2. _Random parts_ - the model's group count (amount of random intercepts) as well as the Intra-Class-Correlation-Coefficient _ICC_ and information on the random effect variances (within-group, between-group etc.)
+1. _Fixed effects_ - the model's fixed effects coefficients, including confidence intervals and p-values.
+2. _Random effects_ - the model's group count (amount of random intercepts) as well as the Intra-Class-Correlation-Coefficient _ICC_ and information on the random effect variances (within-group, between-group etc.)
 3. _Summary_ - Observations, AIC etc.
 
 ```{r}
@@ -129,7 +129,7 @@ Note that in the above example, the order of fitted model was changed. This is s
 
 ## Models with different random intercepts
 
-When models have different random intercepts, the `sjt.lmer()` function tries to detect these information from each model. In the _Random parts_ section of the table, information on multiple grouping levels and ICC's are printed then.
+When models have different random intercepts, the `sjt.lmer()` function tries to detect these information from each model. In the _Random effects_ section of the table, information on multiple grouping levels and ICC's are printed then.
 
 ```{r}
 sjt.lmer(fit1, fit2, fit3)
@@ -185,4 +185,3 @@ sjt.lmer(fit1, fit2, fit3,
          show.re.var = FALSE,
          show.icc = FALSE)
 ```
-


### PR DESCRIPTION
Replaces "Fixed Parts" and "Random Parts" with "Fixed Effects" and "Random Effects", respectively.
Related to issue https://github.com/strengejacke/sjPlot/issues/368.