### PR TITLE
New feature in plot_likert.R: reverse y-axis

### DIFF
--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -52,6 +52,7 @@
 #'          E.g. \code{grid.range = 1.4} will set the axis from -140 to +140\%, however, only
 #'          (valid) axis labels from -100 to +100\% are printed. Neutral categories are
 #'          adjusted to the most left limit.
+#' @param reverse.scale Logical, if \code{TRUE}, the ordering of the categories is reversed, so positive and negative values switch position.
 #'
 #' @inheritParams sjp.grpfrq
 #' @inheritParams sjp.stackfrq
@@ -110,6 +111,7 @@ plot_likert <- function(items,
                        grid.breaks = 0.2,
                        expand.grid = TRUE,
                        digits = 1,
+                       reverse.scale = FALSE,
                        coord.flip = TRUE) {
 
   # check param. if we have a single vector instead of
@@ -611,9 +613,16 @@ plot_likert <- function(items,
     # for neutral category work...
 
     scale_x_continuous(breaks = seq_len(ncol(freq.df)), labels = axis.labels) +
-    scale_y_continuous(breaks = gridbreaks, limits = c(-grid.range, grid.range), expand = expgrid, labels = gridlabs) +
     geom_hline(yintercept = 0, color = intercept.line.color)
 
+  # check wether percentage scale (y-axis) should be reversed
+  
+  if(!reverse.scale) {
+    gp <- gp +scale_y_continuous(breaks = gridbreaks, limits = c(-grid.range, grid.range), expand = expgrid, labels = gridlabs) 
+  } else {
+    gp <- gp +scale_y_reverse(breaks = gridbreaks, limits = c(grid.range, -grid.range), expand = expgrid, labels = gridlabs)
+  }
+  
   # check whether coordinates should be flipped, i.e.
   # swap x and y axis
 

--- a/man/plot_likert.Rd
+++ b/man/plot_likert.Rd
@@ -14,7 +14,7 @@ plot_likert(items, title = NULL, legend.title = NULL,
   reverse.colors = FALSE, values = "show", show.n = TRUE,
   show.legend = TRUE, show.prc.sign = FALSE, grid.range = 1,
   grid.breaks = 0.2, expand.grid = TRUE, digits = 1,
-  coord.flip = TRUE)
+  reverse.scale = FALSE, coord.flip = TRUE)
 }
 \arguments{
 \item{items}{Data frame, with each column representing one item.}
@@ -122,6 +122,8 @@ axes and plotting region. Default is \code{FALSE}.}
 
 \item{digits}{Numeric, amount of digits after decimal point when rounding
 estimates or values.}
+
+\item{reverse.scale}{Logical, if \code{TRUE}, the ordering of the categories is reversed, so positive and negative values switch position.}
 
 \item{coord.flip}{logical, if \code{TRUE}, the x and y axis are swapped.}
 }


### PR DESCRIPTION
Hi,

I added an option to reverse the order of the categories in plot_likert. This is usefull if your data is numbered in the wrong direction or if you want the positives outcomes on the left side. 

I hope you like the way I implemented it. Please tell me if more changes are needed.

Greetings
Alex