### PR TITLE
New Feature plot_liker.R: Set left and right limit separately

### DIFF
--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -495,9 +495,9 @@ plot_likert <- function(items,
     expgrid <- c(0, 0)
   }
 
-  # Set up grid breaks
+  # Set up grid breaks. Calculate grid breaks starting at the center (0). Negative sequence is reversed. Positive sequence is skipping the 0 to avoid doubeling.
 
-  gridbreaks <- round(seq(-grid.range[1], grid.range[2], by = grid.breaks), 2)
+  gridbreaks <- round(c(rev(seq(0, -grid.range[1], by = -grid.breaks)), seq(grid.breaks, grid.range[2], by = grid.breaks)), 2)
   gridlabs <- ifelse(abs(gridbreaks) > 1, "", paste0(abs(round(100 * gridbreaks)), "%"))
 
   # start plot here

--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -46,12 +46,11 @@
 #'          }
 #' @param show.prc.sign Logical, if \code{TRUE}, \%-signs for value labels are shown.
 #' @param grid.range Numeric, limits of the x-axis-range, as proportion of 100.
-#'          Default is 1, so the x-scale ranges from zero to 100\% on
-#'          both sides from the center. You can use values beyond 1
-#'          (100\%) in case bar labels are not printed because they exceed the axis range.
-#'          E.g. \code{grid.range = 1.4} will set the axis from -140 to +140\%, however, only
-#'          (valid) axis labels from -100 to +100\% are printed. Neutral categories are
-#'          adjusted to the most left limit.
+#'          Default is 1, so the x-scale ranges from zero to 100\% on both sides from the center. 
+#'          Can alternatively be supplied as a vector of 2 positive numbers (e.g. \code{grid.range = c(1,0.8)})
+#'          to set the left and right limit separately. You can use values beyond 1 (100\%) in case bar labels are not printed because 
+#'          they exceed the axis range. E.g. \code{grid.range = 1.4} will set the axis from -140 to +140\%, however, only
+#'          (valid) axis labels from -100 to +100\% are printed. Neutral categories are adjusted to the most left limit.
 #' @param reverse.scale Logical, if \code{TRUE}, the ordering of the categories is reversed, so positive and negative values switch position.
 #'
 #' @inheritParams sjp.grpfrq
@@ -119,7 +118,9 @@ plot_likert <- function(items,
 
   if (!is.data.frame(items) && !is.matrix(items)) items <- as.data.frame(items)
 
-
+  # if grid.range is supplied as 1 value, it is duplicated for symmetric results. This is for compatibillity with older versions.
+  if (length(grid.range)==1) grid.range = c(grid.range, grid.range)
+  
   # copy titles
 
   if (is.null(axis.titles)) {
@@ -435,7 +436,7 @@ plot_likert <- function(items,
                     frq = -1 + fr[catcount + adding],
                     ypos = -1 + (fr[catcount + adding] / 2),
                     ypos2 = -1 + fr[catcount + adding],
-                    offset = -1 * grid.range)
+                    offset = -1 * grid.range[1])
         ))
 
       # cumulative neutral cat
@@ -496,7 +497,7 @@ plot_likert <- function(items,
 
   # Set up grid breaks
 
-  gridbreaks <- round(seq(-grid.range, grid.range, by = grid.breaks), 2)
+  gridbreaks <- round(seq(-grid.range[1], grid.range[2], by = grid.breaks), 2)
   gridlabs <- ifelse(abs(gridbreaks) > 1, "", paste0(abs(round(100 * gridbreaks)), "%"))
 
   # start plot here
@@ -600,7 +601,7 @@ plot_likert <- function(items,
 
     if (!is.null(cat.neutral)) {
       gp <- gp +
-        annotate("text", x = xpos.sum.dk, y = ypos.sum.dk + 1 - grid.range, hjust = hort.dk, label = ypos.sum.dk.lab)
+        annotate("text", x = xpos.sum.dk, y = ypos.sum.dk + 1 - grid.range[1], hjust = hort.dk, label = ypos.sum.dk.lab)
     }
   }
 
@@ -618,9 +619,9 @@ plot_likert <- function(items,
   # check wether percentage scale (y-axis) should be reversed
   
   if(!reverse.scale) {
-    gp <- gp +scale_y_continuous(breaks = gridbreaks, limits = c(-grid.range, grid.range), expand = expgrid, labels = gridlabs) 
+    gp <- gp +scale_y_continuous(breaks = gridbreaks, limits = c(-grid.range[1], grid.range[2]), expand = expgrid, labels = gridlabs) 
   } else {
-    gp <- gp +scale_y_reverse(breaks = gridbreaks, limits = c(grid.range, -grid.range), expand = expgrid, labels = gridlabs)
+    gp <- gp +scale_y_reverse(breaks = gridbreaks, limits = c(grid.range[2], -grid.range[1]), expand = expgrid, labels = gridlabs)
   }
   
   # check whether coordinates should be flipped, i.e.

--- a/man/plot_likert.Rd
+++ b/man/plot_likert.Rd
@@ -107,12 +107,11 @@ function, a legend is added to the plot.}
 \item{show.prc.sign}{Logical, if \code{TRUE}, \%-signs for value labels are shown.}
 
 \item{grid.range}{Numeric, limits of the x-axis-range, as proportion of 100.
-Default is 1, so the x-scale ranges from zero to 100\% on
-both sides from the center. You can use values beyond 1
-(100\%) in case bar labels are not printed because they exceed the axis range.
-E.g. \code{grid.range = 1.4} will set the axis from -140 to +140\%, however, only
-(valid) axis labels from -100 to +100\% are printed. Neutral categories are
-adjusted to the most left limit.}
+Default is 1, so the x-scale ranges from zero to 100\% on both sides from the center. 
+Can alternatively be supplied as a vector of 2 positive numbers (e.g. \code{grid.range = c(1,0.8)})
+to set the left and right limit separately. You can use values beyond 1 (100\%) in case bar labels are not printed because 
+they exceed the axis range. E.g. \code{grid.range = 1.4} will set the axis from -140 to +140\%, however, only
+(valid) axis labels from -100 to +100\% are printed. Neutral categories are adjusted to the most left limit.}
 
 \item{grid.breaks}{numeric; sets the distance between breaks for the axis,
 i.e. at every \code{grid.breaks}'th position a major grid is being printed.}


### PR DESCRIPTION
Hi Daniel,

there is another change I needed. I hope you like it.

When visualizing the results of our teaching evaluation, there is a lot of blank space. Or when using `values = "sum.outside"` nudging one limit is often enough. This is why I implemented setting the left and right limit with `grid.range` separately.

My solution tries to provide full backwards compatibility with the current version of `plot_likert`. The limits are supplied as 2 positive numbers to avoid confusion, since the axis labelling is positive in both directions. Please tell me if you prefer to provide the limits as a positive and a negative number.

Sometimes there are labbeling problems, which can be solved using `grid.breaks`. The labbeling problems are less common on symmetric scales, but can still occur. One solution could be to calculate the breaks starting from 0%. If this sounds like a good idea to you, I can make another commit.

Greetings,
Alex

Minimal Example:
```
data(efc)
plot_data <- find_var(efc, pattern = "cop", out = "df")
plot_likert(plot_data, reverse.scale = F, values = "sum.outside", grid.range = c(1,1.1))
plot_likert(plot_data, cat.neutral = 2, reverse.scale = F, grid.range = c(0.8,1))
```