### PR TITLE
Bugfix plot_likert(): add default option for proper y-axis alignment

### DIFF
--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -152,7 +152,7 @@ plot_likert <- function(items,
                         sort.groups = TRUE, # Group Options
                         legend.pos = "bottom",
                         rel_heights = 1,
-                        cowplot.options = list(label_x = 0.01, hjust = 0) # Fix for label position depending on label length bug in cowplot
+                        cowplot.options = list(label_x = 0.01, hjust = 0, align="v") # Fix for label position depending on label length bug in cowplot
                         ) {
 
   # Select options to be passed to .plot_likert()


### PR DESCRIPTION
I forgot a cowplot option for proper y-axis alignment. Without it the y-axis can be misaligned, if the group.titles have large differences in length.

Regarding factor.groups: I choose this name to replicate the naming of sjt.itemanalysis. There the groups are also no factors, but can come from factor analysis.

Greetings
Alex