### PR TITLE
3 minor changes: bugfix and feature for plot_likert and feature for sjt.itemanalysis.

### DIFF
--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -153,7 +153,7 @@ plot_likert <- function(items,
                         sort.groups = TRUE, # Group Options
                         legend.pos = "bottom",
                         rel_heights = 1,
-                        group.legend.options = list(nrow = NULL, byrow = T), # Add rowwise order of levels and option to force a single rowed legend for 6 or more categories
+                        group.legend.options = list(nrow = NULL, byrow = TRUE), # Add rowwise order of levels and option to force a single rowed legend for 6 or more categories
                         cowplot.options = list(label_x = 0.01, hjust = 0, align="v") # Fix for label position depending on label length bug in cowplot
                         ) {
 

--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -65,6 +65,9 @@
 #' @param rel_heights (optional, only used if groups are supplied) This option can be used to adjust the height of the subplots. The bars in subplots can have different heights due to a differing number of items
 #'   or due to legend placement. This can be adjusted here. Takes a vector of numbers, one
 #'   for each plot. Values are evaluated relative to each other.
+#' @param group.legend.options (optional, only used if groups are supplied) List of options to be passed to \code{\link[ggplot2]{guide_legend}}.
+#' The most notable options are \code{byrow=T} (default), this will order the categories row wise.
+#' And with \code{group.legend.options = list(nrow = 1)} all categories can be forced to be on a single row.
 #' @param cowplot.options (optional, only used if groups are supplied) List of label options to be passed to \code{\link[cowplot]{plot_grid}}.
 #'
 #' @inheritParams sjp.grpfrq
@@ -150,6 +153,7 @@ plot_likert <- function(items,
                         sort.groups = TRUE, # Group Options
                         legend.pos = "bottom",
                         rel_heights = 1,
+                        group.legend.options = list(nrow = NULL, byrow = T), # Add rowwise order of levels and option to force a single rowed legend for 6 or more categories
                         cowplot.options = list(label_x = 0.01, hjust = 0, align="v") # Fix for label position depending on label length bug in cowplot
                         ) {
 
@@ -186,9 +190,9 @@ plot_likert <- function(items,
     # If there are 2 or more groups, the legend will be plotted according to legend.pos.
     if (length(findex) != 1) {
       if (legend.pos %in% c("top", "both") & i == 1)
-        .pl <- .pl + theme(legend.position = "top")
+        .pl <- .pl + theme(legend.position = "top") + guides(fill=do.call(guide_legend, group.legend.options))
       else if (legend.pos %in% c("bottom", "both") & i == length(findex))
-        .pl <- .pl + theme(legend.position = "bottom")
+        .pl <- .pl + theme(legend.position = "bottom") + guides(fill=do.call(guide_legend, group.legend.options))
       else if (legend.pos != "all")
         .pl <- .pl + theme(legend.position = "none")
     }

--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -725,8 +725,15 @@ plot_likert <- function(items,
         )
     }
   } else if (values == "sum.inside" || values == "sum.outside") {
+    # choose label offsets for summed proportions
+    move_pos_labels_left = case_when(
+      values == "sum.outside" & !reverse.scale ~ T,
+      values == "sum.inside" & !reverse.scale ~ F,
+      values == "sum.outside" & reverse.scale ~ F,
+      values == "sum.inside" & reverse.scale ~ T
+    )
     # show cumulative outside bar
-    if (values == "sum.outside") {
+    if (move_pos_labels_left) {
       hort.pos <- -0.15
       hort.neg <- 1.15
       hort.dk <- -0.15

--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -730,7 +730,7 @@ plot_likert <- function(items,
     }
   } else if (values == "sum.inside" || values == "sum.outside") {
     # choose label offsets for summed proportions
-    move_pos_labels_left = case_when(
+    move_pos_labels_left = dplyr::case_when(
       values == "sum.outside" & !reverse.scale ~ T,
       values == "sum.inside" & !reverse.scale ~ F,
       values == "sum.outside" & reverse.scale ~ F,

--- a/R/sjTabItemAnalysis.R
+++ b/R/sjTabItemAnalysis.R
@@ -139,11 +139,16 @@ sjt.itemanalysis <- function(df,
   # check encoding
   encoding <- get.encoding(encoding, df)
 
-  # convert ordered factors to labbeled
-  if (all(sapply(df, is.ordered))) df <- sjlabelled::as_labelled(df)
+  # convert ordered factors to numeric
+  ordered_vars <- sapply(df, is.ordered)
+  if (any(ordered_vars)) df[ordered_vars] <- sjlabelled::as_numeric(df[ordered_vars])
 
   # Warn if factors are used
-  if (all(sapply(df, is.factor))) stop("Factors are not allowed. Please check if factor levels are ordered and use sjlabelled::as_labbeled() for conversion.")
+  factor_vars <- sapply(df, is.factor)
+  if (any(factor_vars)) {
+    df[factor_vars] <- sjlabelled::as_numeric(df[factor_vars])
+    warning("At least one variable is of type factor, please check if the factor levels are ordered correctly.")
+  }
 
   # auto-detect variable labels
   varlabels <- sjlabelled::get_label(df, def.value = colnames(df))

--- a/R/sjTabItemAnalysis.R
+++ b/R/sjTabItemAnalysis.R
@@ -139,6 +139,12 @@ sjt.itemanalysis <- function(df,
   # check encoding
   encoding <- get.encoding(encoding, df)
 
+  # convert ordered factors to labbeled
+  if (all(sapply(df, is.ordered))) df <- sjlabelled::as_labelled(df)
+
+  # Warn if factors are used
+  if (all(sapply(df, is.factor))) stop("Factors are not allowed. Please check if factor levels are ordered and use sjlabelled::as_labbeled() for conversion.")
+
   # auto-detect variable labels
   varlabels <- sjlabelled::get_label(df, def.value = colnames(df))
   colnames(df) <- varlabels

--- a/man/plot_likert.Rd
+++ b/man/plot_likert.Rd
@@ -16,8 +16,8 @@ plot_likert(items, groups = NULL, groups.titles = "auto",
   show.prc.sign = FALSE, grid.range = 1, grid.breaks = 0.2,
   expand.grid = TRUE, digits = 1, reverse.scale = FALSE,
   coord.flip = TRUE, sort.groups = TRUE, legend.pos = "bottom",
-  rel_heights = 1, cowplot.options = list(label_x = 0.01, hjust = 0,
-  align = "v"))
+  rel_heights = 1, group.legend.options = list(nrow = NULL, byrow = T),
+  cowplot.options = list(label_x = 0.01, hjust = 0, align = "v"))
 }
 \arguments{
 \item{items}{Data frame, with each column representing one item.}
@@ -146,6 +146,10 @@ If the is only one group or this option is set to \code{"all"} legends will be p
 \item{rel_heights}{(optional, only used if groups are supplied) This option can be used to adjust the height of the subplots. The bars in subplots can have different heights due to a differing number of items
 or due to legend placement. This can be adjusted here. Takes a vector of numbers, one
 for each plot. Values are evaluated relative to each other.}
+
+\item{group.legend.options}{(optional, only used if groups are supplied) List of options to be passed to \code{\link[ggplot2]{guide_legend}}.
+The most notable options are \code{byrow=T} (default), this will order the categories row wise.
+And with \code{group.legend.options = list(nrow = 1)} all categories can be forced to be on a single row.}
 
 \item{cowplot.options}{(optional, only used if groups are supplied) List of label options to be passed to \code{\link[cowplot]{plot_grid}}.}
 }


### PR DESCRIPTION
Hello Daniel,

this time I have 3 minor changes.

1. `sjt.itemanalysis` now works on ordered factors. Ordered factors work with `plot_likert`, which resulted in confusion when `sjt.itemanalysis` failed. I also added a clearer error message if unordered factors are used. The old error message `Error in sum(x) : invalid 'type' (character) of argument` was not helpful. 

2. The `plot_likert` option `reverse.scale = TRUE` resulted in `values = "sum.inside"` being outside and the other way around. This is fixed now. The section could be refactored, maybe the magic numbers for label positioning could be exposed to the user. This would also allow plotting neutral labels inside and pos/neg labels outside (Since neutral labels tend to collide with neighbouring labels).

3. ggplot2 shows category labels in the top and bottom legends in 2 rows if there are more than 6 categories. Also, the categories are ordered column wise instead of row wise. This behaviour can now be controlled for grouped likert plots. The ordering now defaults to row wise and the user can force all categories onto a single row. 

Example code:
```
six_cat_example = data.frame(matrix(sample(1:6, 600, replace = T), ncol = 6))

six_cat_example <- six_cat_example %>% dplyr::mutate_all(~ordered(.,labels = c("+++","++","+","-","--","---")))
six_cat_example_fac <- six_cat_example %>% dplyr::mutate_all(~factor(.,labels = c("+++","++","+","-","--","---")))

# Old default
plot_likert(six_cat_example, groups = c(1,1,1,2,2,2), group.legend.options = list(nrow=2, byrow=F))
# New default
plot_likert(six_cat_example, groups = c(1,1,1,2,2,2))
# Single row
plot_likert(six_cat_example, groups = c(1,1,1,2,2,2), group.legend.options = list(nrow=1))

# Ordered factor
sjt.itemanalysis(six_cat_example)
# Unordered factor
sjt.itemanalysis(six_cat_example_fac)
```
Old default legend
![image](https://user-images.githubusercontent.com/5631424/58748944-dfaed200-847f-11e9-9d07-144ae0ffe745.png)
New default legend
![image](https://user-images.githubusercontent.com/5631424/58748949-f2290b80-847f-11e9-9658-e1d54f7c4452.png)
Single Row
![image](https://user-images.githubusercontent.com/5631424/58748956-040aae80-8480-11e9-9661-51418dbfc56b.png)
