### PR TITLE
Fix rounding errors when using "sum.outside" or "sum.inside"

### DIFF
--- a/R/plot_likert.R
+++ b/R/plot_likert.R
@@ -483,9 +483,9 @@ plot_likert <- function(items,
     # create proportional frequency table
 
     if (is.null(weight.by)) {
-      tab <- round(prop.table(table(items[[i]])), 3)
+      tab <- round(prop.table(table(items[[i]])), digits + 3)
     } else {
-      tab <- round(prop.table(stats::xtabs(weight.by ~ items[[i]])), 3)
+      tab <- round(prop.table(stats::xtabs(weight.by ~ items[[i]])), digits + 3)
     }
 
 


### PR DESCRIPTION
Hello Daniel,

I noticed some rounding errors when using "sum.outside" or "sum.inside". This happened because the output of prop.table is always rounded to 3 digits. Adding 2 categories with >10% could result in rounding errors (99.9% and 100.1% added up). So I added more precision when rounding.

Also, for the option `plot_likert(digits=2)` percentages were shown as 13.10%, since the second decimal place was never available. I don't think anybody should ever use 2 or more decimal places, but this way the solution feels more complete.

Greetings
Alex
