### PR TITLE
Update tab_df_content specifying suitably data.frame element

### DIFF
--- a/R/html_print_utils.R
+++ b/R/html_print_utils.R
@@ -164,7 +164,7 @@ tab_df_content <- function(
         arcstring,
         mcc,
         ccnt,
-        mydf[rcnt, ccnt])
+        mydf[[ccnt]][rcnt])
       )
     }
 


### PR DESCRIPTION
To solve issue #337, data.frame element is suitably specified.
Now, the output of the example
```
data(iris)
library(dplyr)
library(sjPlot)
iris %>% group_by(Species) %>% summarise(counts = n()) %>% tab_df()
```
used in such issue is:
![sjplot2](https://user-images.githubusercontent.com/40892925/71002308-45db0980-20df-11ea-8902-bea71e44c596.png)
