### PR TITLE
plot_model_diag_stan: Global priors are not plotted

### DIFF
--- a/R/plot_diag_stan.R
+++ b/R/plot_diag_stan.R
@@ -9,7 +9,6 @@ plot_diag_stan <- function(model, geom.colors, axis.lim, facets, axis.labels, ..
   alpha <- .3
   scale <- .9
 
-
   if (inherits(model, "brmsfit")) {
 
     # check if brms can be loaded
@@ -17,22 +16,8 @@ plot_diag_stan <- function(model, geom.colors, axis.lim, facets, axis.labels, ..
     if (!requireNamespace("brms", quietly = TRUE))
       stop("Package `brms` needs to be loaded first!", call. = F)
 
-    # check if prior sample are available
-
-    d2 <- brms::prior_samples(model)
-
-    if (is.null(d2))
-      stop("No prior-samples found. Please use option `sample_prior = TRUE` when fitting the model.", call. = FALSE)
-
 
     # get samples from posterior and prior
-
-    d2 <- dplyr::select(
-      d2,
-      string_starts_with("b_", colnames(d2)),
-      -string_starts_with("b_Intercept", colnames(d2))
-    )
-
 
     d1 <- brms::posterior_samples(model)
 
@@ -41,6 +26,14 @@ plot_diag_stan <- function(model, geom.colors, axis.lim, facets, axis.labels, ..
       string_starts_with("b_", colnames(d1)),
       -string_starts_with("b_Intercept", colnames(d1))
     )
+
+
+    # check if prior sample are available
+
+    d2 <- brms::prior_samples(model, pars=colnames(d1))
+
+    if (is.null(d2))
+      stop("No prior-samples found. Please use option `sample_prior = TRUE` when fitting the model.", call. = FALSE)
 
   } else if (inherits(model, c("stanreg", "stanfit"))) {
 


### PR DESCRIPTION
Hello,

Many thanks for your sjPlot package! I really like it how easy model parameters and their uncertainty can be plotted.

In the latest master, I have found a small issue. In a brms model, if priors are set on a global level (specifying the same prior for all parameters) they are not plotted when calling `sjPlot::plot_model(fit, type="diag")`.

MWE:

```r
myd <- data.table(y=rnorm(100))
myd$x1 <- rnorm(100, mean=myd$y, sd=5)
myd$x2 <- rnorm(100, mean=myd$y, sd=10)

fit <- brms::brm(y ~ x1 + x2,
                 data=myd,
                 sample_prior=TRUE,
                 prior=c(brms::set_prior("normal(0, .2)",
                                         class="b")),
                 chains=4, iter=500)

sjPlot::plot_model(fit, type="diag")
```

This produces the following output:
![unnamed-chunk-1-1](https://user-images.githubusercontent.com/20613645/78768975-f752c300-798c-11ea-90c2-b0e74a7bfbf6.png)

This pull request fixes this small issue.

Best regards