### PR TITLE
add closing strong tag for p-value < 0.001

### DIFF
--- a/R/tab_model.R
+++ b/R/tab_model.R
@@ -1439,6 +1439,6 @@ format_p_values <- function(dat, p.style, digits.p, emph.p, p.threshold){
   dat$p.value[dat$p.value == pv] <- "&lt;0.001"
 
   pv <- paste0("<strong>0.", paste(rep("0", digits.p), collapse = ""), "</strong>")
-  dat$p.value[dat$p.value == pv] <- "<strong>&lt;0.001"
+  dat$p.value[dat$p.value == pv] <- "<strong>&lt;0.001</strong>"
   dat
 }


### PR DESCRIPTION
You are missing a closing </strong> tag for p-values <0.001. This will usually render fine, but is not valid html (see https://validator.w3.org/) and creates some problems when using xml. To be more specific: I use the exams package to create exams for students. The export works via an xml-file, but because of the missing closing tag, I am not able to import the file in the learning platform; it is not a valid file. Would be great if you could pull the fix, so that tab_model can be used with the exams package.