### PR TITLE
Update format_p_value

### DIFF
--- a/R/tab_model.R
+++ b/R/tab_model.R
@@ -1455,9 +1455,9 @@ format_p_values <- function(dat, p.style, digits.p, emph.p, p.threshold){
   # indicate p <0.001 ----
 
   pv <- paste0("0.", paste(rep("0", digits.p), collapse = ""))
-  dat$p.value[dat$p.value == pv] <- "&lt;0.001"
+  dat$p.value[dat$p.value == pv] <- paste("&lt;", format(10^(-digits.p), scientific = FALSE), sep = "")
 
   pv <- paste0("<strong>0.", paste(rep("0", digits.p), collapse = ""), "</strong>")
-  dat$p.value[dat$p.value == pv] <- "<strong>&lt;0.001</strong>"
+  dat$p.value[dat$p.value == pv] <- paste("<strong>&lt;", format(10^(-digits.p), scientific = FALSE), "</strong>", sep = "")
   dat
 }


### PR DESCRIPTION
Hi Daniel
thanks for providing this great package!
A p-value is displayed hard coded  to "<0.001" within the format_p_value function, so that it is not sensitive to the number of digits given by 'digits.p'.
Example:
<img width="283" alt="pvalue_smaller0 001" src="https://user-images.githubusercontent.com/31031918/151770326-48946d2d-ca6c-4f83-aefa-bc3dd0f28666.png">
fix:
<img width="270" alt="pvalue_smaller0 00001" src="https://user-images.githubusercontent.com/31031918/151770857-0f6e25a1-98fe-4220-b720-899c3cbecbb3.png">


Would be great if you merge the fix. 