### PR TITLE
Fix for issue #841

### DIFF
--- a/R/plot_stackfrq.R
+++ b/R/plot_stackfrq.R
@@ -197,7 +197,7 @@ plot_stackfrq <- function(items,
 
   if (is.null(legend.labels)) {
     legend.labels <- as.character(sort(unique(unlist(
-      apply(items, 2, function(x) unique(stats::na.omit(x)))))))
+      apply(items, 2, function(x) unique(stats::na.omit(x)), simplify = FALSE)))))
   }
 
   # if we have legend labels, we know the exact


### PR DESCRIPTION
This is fix for issue #841 which was caused by the apply function simplifying results in a way that didn't work for unlist if all items have responses at all points. 

Further illustration of the issue:

```{r}
set.seed(31)
dat1 <- data.frame(matrix(sample(1:4, size = 100, replace = TRUE), ncol = 10))
sjPlot::plot_stackfrq(dat1)
set.seed(32)
dat2 <- data.frame(matrix(sample(1:4, size = 100, replace = TRUE), ncol = 10))
sjPlot::plot_stackfrq(dat2)
sjPlot::plot_stackfrq(dat2, legend.labels = 1:4)

apply(dat1, MARGIN = 2, FUN = function(x) length(unique(x)))
apply(dat2, MARGIN = 2, FUN = function(x) length(unique(x)))
``` 
Note that all items in dat2 have 4 different responses, while not all items in dat1 do.