### PR TITLE
Moved glmmTMB require statement in plot_type_ranef to come after the model class check

### DIFF
--- a/R/plot_type_ranef.R
+++ b/R/plot_type_ranef.R
@@ -30,22 +30,23 @@ plot_type_ranef <- function(model,
   if (!requireNamespace("lme4", quietly = TRUE)) {
     stop("Package 'lme4' required for this function to work, please install it.")
   }
-  if (!requireNamespace("glmmTMB", quietly = TRUE)) {
-    stop("Package 'glmmTMB' required for this function to work, please install it.")
-  }
 
   # get tidy output of summary ----
 
-  if (inherits(model, "glmmTMB"))
-    rand.ef <- glmmTMB::ranef(model)[[1]]
-  else if (inherits(model, "MixMod")) {
-    rand.ef <- lme4::ranef(model)
-    if (!is.list(rand.ef)) {
-      rand.ef <- list(rand.ef)
-      names(rand.ef) <- insight::find_random(model, flatten = TRUE)
+  if (inherits(model, "glmmTMB")) {
+    if (!requireNamespace("glmmTMB", quietly = TRUE)) {
+      stop("Package 'glmmTMB' required for this function to work, please install it.")
     }
-  } else
+    rand.ef <- glmmTMB::ranef(model)[[1]]
+  } else {
     rand.ef <- lme4::ranef(model)
+    if (inherits(model, "MixMod")) {
+      if (!is.list(rand.ef)) {
+        rand.ef <- list(rand.ef)
+        names(rand.ef) <- insight::find_random(model, flatten = TRUE)
+      }
+    }
+  }
 
 
   if (inherits(model, "clmm"))


### PR DESCRIPTION
Calling `plot_model()` with `type = "re"` (and by extension `plot_type_ranef()`) on an `lme4` model object currently throws an error if `glmmTMB` is not installed: `Package 'glmmTMB' required for this function to work, please install it.`  

However, looking at the `plot_type_ranef()` code it doesn't seem like `glmmTMB` is actually necessary to plot `lme4` ranefs. There is a [require call](https://github.com/strengejacke/sjPlot/blob/fdd1448a52efa39b936a0149a665a70be1d9a4c8/R/plot_type_ranef.R#L33) for `glmmTMB` at the top of `plot_type_ranef()`, before the control flow actually checks whether the model is an `lme4` or `glmmTMB` model.

I've moved the `glmmTMB` require statement so that the model class is checked first. If `glmmTMB` is not actually necessary, not having it installed won't throw an error.

I considered moving the `lme4` require statement as well, but `sjstats` (and by extension `sjPlot`) has it as a hard dependency anyway, so it should always be installed if `plot_type_ranef()` is called.