### PR TITLE
in plot_type_int, allow transformed interaction terms

### DIFF
--- a/R/plot_type_int.R
+++ b/R/plot_type_int.R
@@ -27,7 +27,7 @@ plot_type_int <- function(model,
 
   # get interaction terms and model frame
 
-  ia.terms <- purrr::map(int.terms, ~ sjmisc::trim(unlist(strsplit(.x, "[\\*:]"))))
+  ia.terms <- purrr::map(int.terms, ~ insight::clean_names(unlist(strsplit(.x, "[\\*:]"))))
   mf <- insight::get_data(model, verbose = FALSE)
 
   pl <- list()


### PR DESCRIPTION
Closes #940

`insight::clean_names` internally uses `insight::trim_ws` at the end, so it can cleanly replace `sjmisc::trim`